### PR TITLE
JPA constructor visibility fix

### DIFF
--- a/src/main/java/org/ubp/ent/backend/core/domains/classroom/ClassroomDomain.java
+++ b/src/main/java/org/ubp/ent/backend/core/domains/classroom/ClassroomDomain.java
@@ -38,7 +38,7 @@ public class ClassroomDomain implements ModelTransformable<Classroom, Long> {
     private Set<ClassroomType> types;
 
     @SuppressWarnings("unused")
-    public ClassroomDomain() {
+    protected ClassroomDomain() {
     }
 
     public ClassroomDomain(Classroom classroom) {

--- a/src/main/java/org/ubp/ent/backend/core/domains/classroom/equipement/EquipmentTypeDomain.java
+++ b/src/main/java/org/ubp/ent/backend/core/domains/classroom/equipement/EquipmentTypeDomain.java
@@ -21,7 +21,7 @@ public class EquipmentTypeDomain implements ModelTransformable<EquipmentType, Lo
     private String name;
 
     @SuppressWarnings("unused")
-    public EquipmentTypeDomain() {
+    protected EquipmentTypeDomain() {
     }
 
     public EquipmentTypeDomain(EquipmentType equipmentType) {

--- a/src/main/java/org/ubp/ent/backend/core/domains/classroom/equipement/RoomEquipmentDomain.java
+++ b/src/main/java/org/ubp/ent/backend/core/domains/classroom/equipement/RoomEquipmentDomain.java
@@ -24,7 +24,7 @@ public class RoomEquipmentDomain implements ModelTransformable<RoomEquipment, Ro
     private int quantity;
 
     @SuppressWarnings("unused")
-    public RoomEquipmentDomain() {
+    protected RoomEquipmentDomain() {
     }
 
     public RoomEquipmentDomain(RoomEquipment roomEquipment, ClassroomDomain classroomDomain) {

--- a/src/main/java/org/ubp/ent/backend/core/domains/classroom/equipement/RoomEquipmentDomainId.java
+++ b/src/main/java/org/ubp/ent/backend/core/domains/classroom/equipement/RoomEquipmentDomainId.java
@@ -22,7 +22,7 @@ public class RoomEquipmentDomainId implements Serializable {
     private EquipmentTypeDomain equipmentType;
 
 
-    public RoomEquipmentDomainId() {
+    protected RoomEquipmentDomainId() {
     }
 
     public RoomEquipmentDomainId(ClassroomDomain classroom, EquipmentTypeDomain equipmentType) {


### PR DESCRIPTION
JPA constructor is not protected, jpa can use it, but won't be avaliable for developper outside the package or inheritance